### PR TITLE
Use TZ environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - /run/udev:/run/udev:ro
     devices:
       - ${ZIGBEE_USB_ADAPTER}:/dev/ttyACM0
+    environment:
+      - TZ=${TZ}
     group_add:
       - dialout
   homebridge:
@@ -25,6 +27,8 @@ services:
     network_mode: host
     volumes:
       - homebridge_data:/homebridge
+    environment:
+      - TZ=${TZ}
   node-red:
     container_name: node-red
     image: nodered/node-red
@@ -32,6 +36,8 @@ services:
     network_mode: host
     volumes:
       - node-red_data:/data
+    environment:
+      - TZ=${TZ}
 volumes:
   zigbee2mqtt_data:
   homebridge_data:


### PR DESCRIPTION
`TZ` was moved to environment (https://github.com/kszubrycht/zigbee2homekit/pull/7) but not used in compose file

